### PR TITLE
hotfix for api job failing on grabbing appt hash time key

### DIFF
--- a/app/jobs/vaccine_spotter_v0_api_job.rb
+++ b/app/jobs/vaccine_spotter_v0_api_job.rb
@@ -67,7 +67,11 @@ class VaccineSpotterV0ApiJob < ApplicationJob
     # This 'if' covers the case where params_hash[:vaccines_available]=true, but appt array is empty.
     # Assume there are appts, and the day last fetched the the appt day. Often this is the case when looking at the raw data
     if params_hash[:appointments].length == 0
-      date = params_hash[:appointments_last_fetched].to_datetime.strftime('%Y/%m/%d')
+      if params_hash[:appointments_last_fetched].nil? == true
+        date = DateTime.now.strftime('%Y/%m/%d') #naive assumption the appt is today
+      else
+        date = params_hash[:appointments_last_fetched].to_datetime.strftime('%Y/%m/%d')
+      end
       vaccines_available = '' #naive assumption for now
       appointment_hash = {
         location_id: location_id,
@@ -84,7 +88,11 @@ class VaccineSpotterV0ApiJob < ApplicationJob
       dates_seen = []
       params_hash[:appointments].each do |a|
         vaccines_available = '' #naive assumption for now
-        date = a[:time].to_datetime.strftime('%Y/%m/%d')
+        if a["time"].nil? == true #formatted as {"time"=>"2021-03-19T09:45:00.000-07:00"}
+          next
+        else
+          date = a["time"].to_datetime.strftime('%Y/%m/%d')
+        end
         if dates_seen.include? date
           next
         end

--- a/config/application.rb
+++ b/config/application.rb
@@ -4,6 +4,7 @@ require "rails/all"
 require 'csv'
 require 'json'
 require 'net/http'
+require 'date'
 
 # Require the gems listed in Gemfile, including any gems
 # you've limited to :test, :development, or :production.


### PR DESCRIPTION
trying to catch issues with time, when the last_fetched key returns a nil value, we just put in today's date... the naive assumption. For the appt, if its array has nil times, we just skip these as they can be anything. 