### PR TITLE
super fix for perform_start.active_job log nil any? error

### DIFF
--- a/app/jobs/aggregate_tweet_job.rb
+++ b/app/jobs/aggregate_tweet_job.rb
@@ -14,6 +14,7 @@ class AggregateTweetJob < ApplicationJob
   end
 
   def initialize
+    super()
     @aggregate_appts_to_tweet = []
   end
 


### PR DESCRIPTION
references this same issue: https://github.com/rails/rails/issues/25977

error I got: 
```
Running rake aggregate_tweet_job on ⬢ vaxspotter... up, run.4428 (Hobby)
Running the AggregateTweetJob job now......
E, [2021-03-26T07:47:11.514847 #4] ERROR -- : [ActiveJob] [AggregateTweetJob] Could not log "perform_start.active_job" event. NoMethodError: undefined method `any?' for nil:NilClass ["/app/vendor/bundle/ruby/2.7.0/gems/activejob-6.1.3/lib/active_job/log_subscriber.rb:109:in `args_info'"
```
job still completed though.

Specifically useful post:
https://github.com/rails/rails/issues/25977#issuecomment-236068998